### PR TITLE
Add "Replace Existing Content" Feature

### DIFF
--- a/assets/css/mc-acf-ft-css.css
+++ b/assets/css/mc-acf-ft-css.css
@@ -47,6 +47,9 @@ button.handlediv.acf-mc-ft-close:hover {
 .acf-mc-import-content select.acf-templates-select, .acf-mc-ft-save-wrap select.acf-templates-terms-select {
     min-width: 341px;
 }
+.acf-mc-ft-replace-content {
+    margin-bottom: 15px;
+}
 .acf-mc-ft-wrap .acf-success-message {
     border: 2px solid #46b450;
     border-radius: 3px;

--- a/assets/js/mc-acf-ft-template.js
+++ b/assets/js/mc-acf-ft-template.js
@@ -98,14 +98,14 @@ jQuery(document).ready(function($){
 
                     if(  true === json.success ) {
 
-                        var $replace = $el.closest('.acf-mc-import-content').find('input[name=replace_content]');		
+			var $replace = $el.closest('.acf-mc-import-content').find('input[name=replace_content]');
 			if( $replace.is(':checked') ) {
-							
+
 				var $layouts = parentValues.find( '.layout' );
 				$layouts.each( function( key, value ) {
 					acfFlexible.removeLayout( $(value) );
 				});
-						
+
 			}
                         
                         $( error_div ).hide();

--- a/assets/js/mc-acf-ft-template.js
+++ b/assets/js/mc-acf-ft-template.js
@@ -98,6 +98,17 @@ jQuery(document).ready(function($){
 
                     if(  true === json.success ) {
 
+                        var $replace = $el.closest('.acf-mc-import-content').find('input[name=replace_content]');
+					
+						if( $replace.is(':checked') ) {
+							
+							var $layouts = parentValues.find( '.layout' );
+								$layouts.each( function( key, value ) {
+									acfFlexible.removeLayout( $(value) );
+								});
+						
+						}
+                        
                         $( error_div ).hide();
 
                         var layoutsHtml =  $( json.data.layouts );

--- a/assets/js/mc-acf-ft-template.js
+++ b/assets/js/mc-acf-ft-template.js
@@ -98,16 +98,15 @@ jQuery(document).ready(function($){
 
                     if(  true === json.success ) {
 
-                        var $replace = $el.closest('.acf-mc-import-content').find('input[name=replace_content]');
-					
-						if( $replace.is(':checked') ) {
+                        var $replace = $el.closest('.acf-mc-import-content').find('input[name=replace_content]');		
+			if( $replace.is(':checked') ) {
 							
-							var $layouts = parentValues.find( '.layout' );
-								$layouts.each( function( key, value ) {
-									acfFlexible.removeLayout( $(value) );
-								});
+				var $layouts = parentValues.find( '.layout' );
+				$layouts.each( function( key, value ) {
+					acfFlexible.removeLayout( $(value) );
+				});
 						
-						}
+			}
                         
                         $( error_div ).hide();
 

--- a/includes/class-mc-acf-flexible-template.php
+++ b/includes/class-mc-acf-flexible-template.php
@@ -224,6 +224,7 @@ if( !class_exists('MC_Acf_Flexible_Template') ) {
                             <?php endif; ?>
                         </select>
                     </label>
+                    <div class="replace-content"><input name="replace_content" value="" type="checkbox"><?php _e( 'Replace existing content', 'mc-acf-ft-template' ); ?></div>
                     <button class="acf-mc-ft-import acf-button button button-secondary"><?php _e( 'Load', 'mc-acf-ft-template' ); ?></button>
                     <?php else: ?>
                         <p><?php _e( 'No template found for this flexible', 'mc-acf-ft-template' ); ?></p>

--- a/includes/class-mc-acf-flexible-template.php
+++ b/includes/class-mc-acf-flexible-template.php
@@ -224,7 +224,7 @@ if( !class_exists('MC_Acf_Flexible_Template') ) {
                             <?php endif; ?>
                         </select>
                     </label>
-                    <div class="replace-content"><input name="replace_content" value="" type="checkbox"><?php _e( 'Replace existing content', 'mc-acf-ft-template' ); ?></div>
+                    <div class="acf-mc-ft-replace-content"><input name="replace_content" value="" type="checkbox"><?php _e( 'Replace existing content', 'mc-acf-ft-template' ); ?></div>
                     <button class="acf-mc-ft-import acf-button button button-secondary"><?php _e( 'Load', 'mc-acf-ft-template' ); ?></button>
                     <?php else: ?>
                         <p><?php _e( 'No template found for this flexible', 'mc-acf-ft-template' ); ?></p>

--- a/includes/class-mc-acf-flexible-template.php
+++ b/includes/class-mc-acf-flexible-template.php
@@ -224,7 +224,7 @@ if( !class_exists('MC_Acf_Flexible_Template') ) {
                             <?php endif; ?>
                         </select>
                     </label>
-                    <div class="acf-mc-ft-replace-content"><input name="replace_content" value="" type="checkbox"><?php _e( 'Replace existing content', 'mc-acf-ft-template' ); ?></div>
+                    <label class="acf-mc-ft-replace-content"><input name="replace_content" value="" type="checkbox"><?php _e( 'Replace existing content', 'mc-acf-ft-template' ); ?></label>
                     <button class="acf-mc-ft-import acf-button button button-secondary"><?php _e( 'Load', 'mc-acf-ft-template' ); ?></button>
                     <?php else: ?>
                         <p><?php _e( 'No template found for this flexible', 'mc-acf-ft-template' ); ?></p>


### PR DESCRIPTION
@MarieComet 

This pull request is related to the following [feature request](https://github.com/MarieComet/mc-acf-flexible-template/issues/11) 

Basically, this is the list of changes:
1. a "replace content" `checkbox` has been added into the import tab layout (just before the load button)
2. a bit of css as been added to add  margin between the checkbox and the load button.
3. all the js logic has been added into the `mc-acf-ft-template.js`. This logic simply removes all current flexible layouts before performing the template import. This logic is executed only if the ajax request has a `success` response.

The feature should be complete and has been tested. 
However would be useful doing some other tests before merging.

Hope to see this feature merged soon :)

![replace-existing-content](https://user-images.githubusercontent.com/6567583/47236695-3c6fe780-d3dd-11e8-871e-40d84c7c7e1a.jpg)
