### PR TITLE
Added a composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name"        : "mariecomet/mc-acf-flexible-template"
+    "description" : "Makes it possible to save the ACF flexible content fields as templates and to use them again.",
+    "keywords"    : ["wordpress"],
+    "homepage"    : "https://github.com/MarieComet/mc-acf-flexible-template",
+    "license"     : "GPL-2.0+",
+    "type"        : "wordpress-plugin",
+    "authors"     : [
+	{
+	    "name"     : "Marie Comet",
+	    "homepage" : "https://www.mariecomet.fr"
+	}
+    ],
+    "require"     : {
+	"composer/installers" : "^1.0",
+	"php"                 : ">=5.3.0"
+    }
+}


### PR DESCRIPTION
By adding a `composer.json` file to the repository, you'd allow people relying on `Bedrock` to very simply reference your plugin as part of their installation (without even the need for you to create an official plugin on WP.org).

I set license GPL-2.0+ since I didn't find a reference and it seems like mandatory choice for WP plugins.
