### PR TITLE
Fix acf.doAction('validation_begin')

### DIFF
--- a/assets/js/mc-acf-ft-template.js
+++ b/assets/js/mc-acf-ft-template.js
@@ -192,7 +192,7 @@ jQuery(document).ready(function($){
             
             $form = $( 'form#post' );
 
-            acf.do_action( 'validation_begin' );
+            acf.doAction('validation_begin', $form);
 
             var data = acf.serialize( parentValues );
             


### PR DESCRIPTION
Added fix for compatibility. `acf.doAction('validation_begin', $form);` now provides `$form` as parameter to fit native ACF hook usage & let other plugins use the hook. Tested and working.